### PR TITLE
Feature/caiman

### DIFF
--- a/software/PrecomputeCellCheck/PrecomputeCellCheck.m
+++ b/software/PrecomputeCellCheck/PrecomputeCellCheck.m
@@ -30,6 +30,7 @@ function PrecomputeCellCheck(matfile_path, h5file_path, varargin)
     addParameter(p, 'parallel', true, @islogical);
     addParameter(p, 'dt', 1, @isnumeric);
     addParameter(p, 'fast_features', false, @islogical);
+    addParameter(p, 'algorithm', 1, @isnumeric);  % [new]
     addParameter(p, 'progressDlg', [], @isobject);
     addParameter(p, 'UIFigure', [], @isobject);
 
@@ -42,6 +43,7 @@ function PrecomputeCellCheck(matfile_path, h5file_path, varargin)
     progressDlg = p.Results.progressDlg;
     UIFigure = p.Results.UIFigure;
     fast_features = p.Results.fast_features; 
+    algorithm = p.Results.algorithm; % [new]
 
     % Run parallel pool if parallel is on
     if parallel && isempty(gcp('nocreate'))
@@ -85,18 +87,33 @@ function PrecomputeCellCheck(matfile_path, h5file_path, varargin)
     end
 
     update_progress("Loading H5 File... DONE!", 0.1, progressDlg); %Update progress
+    
 
-    % Load the .mat file
+    %% Format Converter [new]
+
     start_load_mat_file = posixtime(datetime);
 
-    try
-        extract_output = load(matfile_path);
-    catch
-        raise_alert("Invalid Files!",'error', progressDlg, UIFigure);
-        return
+    switch algorithm
+        case 1 % Load the .mat file
+            disp('Loading EXTRACT inputs ...');
+            try
+                extract_output = load(matfile_path);
+            catch
+                raise_alert("Invalid Files!",'error', progressDlg, UIFigure);
+                return
+            end
+
+        case 2
+            disp('Converting CAIMAN inputs ...');
+            extract_output = caiman_converter(matfile_path);
+                        
+        case 3
+            disp('Converting Suite2p inputs ...');
+            % Leaving for Suite2p-to-Extract function
+         
     end
 
-    update_progress("Loading MAT File... DONE!", 0.2, progressDlg); %Update progress
+    update_progress("Loading Data File... DONE!", 0.2, progressDlg); %Update progress
     PRECOMPUTE_TIME_SUMMARY.load_mat_file = posixtime(datetime) - start_load_mat_file;
 
     % Check if cancelled

--- a/software/PrecomputeCellCheck/PrecomputeCellCheckGUI.m
+++ b/software/PrecomputeCellCheck/PrecomputeCellCheckGUI.m
@@ -8,10 +8,11 @@ function PrecomputeCellCheckGUI
 
     % State storage
     S.jobQueue = struct('h5', {}, 'mat', {}, 'output', {}, ...
-                        'parallel', {}, 'fast', {}, 'dt', {}, 'status', {});
+                        'parallel', {}, 'fast', {}, 'dt', {}, 'status', {},'algorithm',{});
     S.isRunning = false;
     S.selectedJobIndex = [];
-    
+    S.currentChannel = 1;
+
     % Create main figure
     S.fig = uifigure('Name','PrecomputeCellCheckGUI','Position',[100 100 420 520]);
 
@@ -24,12 +25,12 @@ function PrecomputeCellCheckGUI
     S.AddFilesTab = uitab(S.TabGroup,'Title','Add Files');
     S.GridLayout = uigridlayout(S.AddFilesTab,...
         'ColumnWidth',{'0.25x','1x','1x','1x','1x','1x','0.25x'}, ...
-        'RowHeight',{'1.5x','1.25x','1x','1.25x','1x','1.25x','1x',...
+        'RowHeight',{'1.5x','1.25x','1x','1x','1.25x','1.25x','1x','1.25x','1x',...
                      '0.75x','0.75x','0.75x','1x','1.5x','0.25x'});
 
     % Instructions label
     S.InstructionsLabel = uilabel(S.GridLayout,'Text',...
-        'Add pairs of H5 and .mat files to the queue for precomputation:', ...
+        'Add pairs of movie and data files to the queue for precomputation:', ...
         'FontSize',13,'WordWrap','on');
     S.InstructionsLabel.Layout.Row = 1;
     S.InstructionsLabel.Layout.Column = [2 6];
@@ -44,59 +45,77 @@ function PrecomputeCellCheckGUI
         'ValueChangedFcn',@onH5ValueChanged);
     S.H5FileEditField.Layout.Row = 3;
     S.H5FileEditField.Layout.Column = [2 6];
+    
+    % Choose data form [new]
+    S.ChannelHint = uilabel(S.GridLayout,'Text','Channel Selection','FontSize',13);  
+    S.ChannelHint.Layout.Row = 4;
+    S.ChannelHint.Layout.Column = [2 6];
 
-    % Choose .mat
-    S.ChooseMatfileButton = uibutton(S.GridLayout,'push','Text','Choose .mat file',...
+    S.ChannelGroup = uibuttongroup(S.GridLayout,'BorderType','none');  
+    S.ChannelGroup.Layout.Row = 5;
+    S.ChannelGroup.Layout.Column = [2 6];
+
+    S.Radio1 = uiradiobutton(S.ChannelGroup,'Text','EXTRACT','FontSize',12,'Value',true,'Position',[10 10 100 22]);
+    S.Radio2 = uiradiobutton(S.ChannelGroup,'Text','CAIMAN','FontSize',12,'Value',false,'Position',[120 10 100 22]);
+    S.Radio3 = uiradiobutton(S.ChannelGroup,'Text','Suite2p','FontSize',12,'Value',false,'Position',[230 10 100 22]);
+   
+    S.ChannelGroup.SelectionChangedFcn = @onChannelSelectionChanged;
+    
+    S.ChooseDatafileButton = [];
+    S.DataFileEditField = [];
+
+    S.ChooseDatafileButton = uibutton(S.GridLayout,'push','Text','Choose .mat file',...
         'FontSize',13,'ButtonPushedFcn',@onChooseMat);
-    S.ChooseMatfileButton.Layout.Row = 4;
-    S.ChooseMatfileButton.Layout.Column = [2 6];
-
-    S.MatFileEditField = uieditfield(S.GridLayout,'text','FontSize',13,...
-        'ValueChangedFcn',@onMatValueChanged);
-    S.MatFileEditField.Layout.Row = 5;
-    S.MatFileEditField.Layout.Column = [2 6];
-
+    S.ChooseDatafileButton.Layout.Row = 6;
+    S.ChooseDatafileButton.Layout.Column = [2 6];
+    
+    S.DataFileEditField = uieditfield(S.GridLayout,'text','FontSize',13,...
+        'ValueChangedFcn',@onDataValueChanged);
+    S.DataFileEditField.Layout.Row = 7;
+    S.DataFileEditField.Layout.Column = [2 6];
+    
+   
     % Choose output
     S.ChooseOutputButton = uibutton(S.GridLayout,'push','Text','Choose output destination',...
         'FontSize',13,'Enable','off','ButtonPushedFcn',@onChooseOutput);
-    S.ChooseOutputButton.Layout.Row = 6;
+    S.ChooseOutputButton.Layout.Row = 8;
     S.ChooseOutputButton.Layout.Column = [2 6];
 
     S.OutputPathEditField = uieditfield(S.GridLayout,'text','FontSize',13,...
         'Enable','off');
-    S.OutputPathEditField.Layout.Row = 7;
+    S.OutputPathEditField.Layout.Row = 9;
     S.OutputPathEditField.Layout.Column = [2 6];
 
     % Checkboxes
     S.UseParallelComputationCheckBox = uicheckbox(S.GridLayout,'Text','Use Parallel Computation',...
         'FontSize',13,'Value',true,'Enable','off');
-    S.UseParallelComputationCheckBox.Layout.Row = 8;
+    S.UseParallelComputationCheckBox.Layout.Row = 10;
     S.UseParallelComputationCheckBox.Layout.Column = [2 6];
 
     S.FastFeatureCalculationCheckBox = uicheckbox(S.GridLayout,'Text','Fast Feature Calculation',...
         'FontSize',13,'Value',false,'Enable','off');
-    S.FastFeatureCalculationCheckBox.Layout.Row = 9;
+    S.FastFeatureCalculationCheckBox.Layout.Row = 11;
     S.FastFeatureCalculationCheckBox.Layout.Column = [2 6];
 
     % Downsampling
     S.DownsamplingAmountofTimeLabel = uilabel(S.GridLayout,'Text','Downsampling Amount of Time:',...
         'FontSize',13,'Enable','off','WordWrap','on');
-    S.DownsamplingAmountofTimeLabel.Layout.Row = 10;
+    S.DownsamplingAmountofTimeLabel.Layout.Row = 12;
     S.DownsamplingAmountofTimeLabel.Layout.Column = [2 6];
 
     S.DownsamplingAmountEditField = uieditfield(S.GridLayout,'numeric','FontSize',13,...
         'Value',1,'Enable','off','Limits',[1 Inf]);
-    S.DownsamplingAmountEditField.Layout.Row = 11;
+    S.DownsamplingAmountEditField.Layout.Row = 13;
     S.DownsamplingAmountEditField.Layout.Column = [2 6];
 
     % Add to queue
     S.AddToQueueButton = uibutton(S.GridLayout,'push','Text','+ Add to the queue',...
         'FontSize',13,'Enable','off','ButtonPushedFcn',@onAddToQueue);
-    S.AddToQueueButton.Layout.Row = 12;
+    S.AddToQueueButton.Layout.Row = 14;
     S.AddToQueueButton.Layout.Column = [2 6];
 
     % Temporary paths for current entry
-    S.matFilePath = "";
+    S.dataFilePath = "";
     S.h5FilePath = "";
 
     %------------------------------------------------
@@ -154,14 +173,48 @@ function PrecomputeCellCheckGUI
         tryEnableInputs();
     end
 
-    function onChooseMat(~,~)
+    function onChooseMat(~,~)   % [new]
         [file, path] = uigetfile('*.mat','Select .mat file');
         if isequal(file,0)
             return;
         end
-        S.matFilePath = fullfile(path,file);
-        S.MatFileEditField.Value = S.matFilePath;
+        S.dataFilePath = fullfile(path,file);
+        S.DataFileEditField.Value = S.dataFilePath;
         tryEnableInputs();
+    end
+
+    function onChooseHdf5(~,~)  % [new]
+        [file, path] = uigetfile('*.hdf5','Select .hdf5 file');
+        if isequal(file,0)
+            return;
+        end
+        S.dataFilePath = fullfile(path,file);
+        S.DataFileEditField.Value = S.dataFilePath;
+        tryEnableInputs();
+    end
+    
+    function onChooseNpy(~,~)   % [new]
+        [file, path] = uigetfile('*.npy','Select .npy file');
+        if isequal(file,0)
+            return;
+        end
+        S.dataFilePath = fullfile(path,file);
+        S.DataFileEditField.Value = S.dataFilePath;
+        tryEnableInputs();
+    end
+    
+    function updateDataFileButton()    % [new]
+        switch S.currentChannel
+        case 1   % Extract
+            S.ChooseDatafileButton.Text = 'Choose .mat file';
+            S.ChooseDatafileButton.ButtonPushedFcn = @onChooseMat;
+        case 2   % Caiman
+            S.ChooseDatafileButton.Text = 'Choose .hdf5 file';
+            S.ChooseDatafileButton.ButtonPushedFcn = @onChooseHdf5;
+            case 3   % Suite2p
+            S.ChooseDatafileButton.Text = 'Choose .npy file';
+            S.ChooseDatafileButton.ButtonPushedFcn = @onChooseNpy;
+        end
     end
 
     function onChooseOutput(~,~)
@@ -177,19 +230,42 @@ function PrecomputeCellCheckGUI
         tryEnableInputs();
     end
 
-    function onMatValueChanged(~,~)
-        S.matFilePath = S.MatFileEditField.Value;
+    function onChannelSelectionChanged(~,event)   % [new] 
+        selectedButton = event.NewValue;
+        selectedText = selectedButton.Text;
+
+        switch selectedText
+            case 'EXTRACT'
+                S.currentChannel = 1;
+            case 'CAIMAN'
+                S.currentChannel = 2;
+            case 'Suite2p'
+                S.currentChannel = 3;
+        end
+
+        updateDataFileButton();
+
+        S.dataFilePath = "";
+        S.DataFileEditField.Value = "";
+
+        tryEnableInputs();
+
+    end
+
+    function onDataValueChanged(~,~)
+        S.DataFilePath = S.DataFileEditField.Value;
         tryEnableInputs();
     end
 
     function onAddToQueue(~,~)
         job.h5       = S.h5FilePath;
-        job.mat      = S.matFilePath;
+        job.mat      = S.dataFilePath;
         job.output   = S.OutputPathEditField.Value;
         job.parallel = S.UseParallelComputationCheckBox.Value;
         job.fast     = S.FastFeatureCalculationCheckBox.Value;
         job.dt       = S.DownsamplingAmountEditField.Value;
         job.status   = "Ready";
+        job.algorithm = S.currentChannel;     % [new] save data resource
 
         S.jobQueue(end+1) = job;
         updateJobListDisplay();
@@ -253,7 +329,8 @@ function PrecomputeCellCheckGUI
                     'output_path', job.output, ...
                     'parallel', job.parallel, ...
                     'fast_features', job.fast, ...
-                    'dt', job.dt);
+                    'dt', job.dt, ...
+                    'algorithm', job.algorithm);
                 
                 S.jobQueue(1).status = "Done!";
             catch e
@@ -276,8 +353,8 @@ function PrecomputeCellCheckGUI
     % ------------------
 
     function tryEnableInputs()
-        if strlength(S.matFilePath)>0 && strlength(S.h5FilePath)>0
-            outPath = fullfile(fileparts(S.matFilePath),"precomputed_output.mat");
+        if strlength(S.dataFilePath)>0 && strlength(S.h5FilePath)>0
+            outPath = fullfile(fileparts(S.dataFilePath),"precomputed_output.mat");
             S.OutputPathEditField.Value = outPath;
 
             S.ChooseOutputButton.Enable = 'on';
@@ -291,10 +368,10 @@ function PrecomputeCellCheckGUI
     end
 
     function resetAddFilesTab()
-        S.matFilePath = "";
+        S.dataFilePath = "";
         S.h5FilePath = "";
         S.H5FileEditField.Value = "";
-        S.MatFileEditField.Value = "";
+        S.DataFileEditField.Value = "";
         S.OutputPathEditField.Value = "";
         
         S.ChooseOutputButton.Enable = 'off';
@@ -315,6 +392,7 @@ function PrecomputeCellCheckGUI
             S.JobsListBox.Items = cellstr("(No jobs in the queue)");
             S.JobsListBox.ItemsData = 0;
             S.JobsListBox.Value = 0;
+            S.selectedJobIndex = [];
         else
             items = strings(1, numel(S.jobQueue));
             for k = 1:numel(S.jobQueue)
@@ -322,11 +400,22 @@ function PrecomputeCellCheckGUI
                 [~, matName, matExt] = fileparts(j.mat);
                 [~, h5Name,  h5Ext]  = fileparts(j.h5);
                 [~, outName, outExt] = fileparts(j.output);
+                
+                switch j.algorithm
+                    case 1
+                        algo = 'EXTRACT';
+                    case 2
+                        algo = 'CAIMAN';
+                    case 3
+                        algo = 'Suite2p';
+                    otherwise
+                        algo = 'Unknown';
+                end
 
-                items(k) = sprintf("%s%s\n%s%s\nSave as: %s%s\nParallel: %s, Downsampling: %d, Fast: %s, Status: %s",...
+                items(k) = sprintf("%s%s\n%s%s\nSave as: %s%s\nParallel: %s, Downsampling: %d, Fast: %s, Input type: %s\n Status: %s",...
                     matName, matExt, h5Name, h5Ext, outName, outExt,...
                     ternary(j.parallel,"Yes","No"),...
-                    j.dt, ternary(j.fast,"Yes","No"), j.status);
+                    j.dt, ternary(j.fast,"Yes","No"), algo, j.status);
             end
             S.JobsListBox.Items = cellstr(items);
             S.JobsListBox.ItemsData = 1:numel(S.jobQueue);

--- a/software/PrecomputeCellCheck/helper_functions/caiman_converter.m
+++ b/software/PrecomputeCellCheck/helper_functions/caiman_converter.m
@@ -1,4 +1,4 @@
-function status = CAIMAN_to_EXTRACT_converter(filepath,savepath)
+function output = caiman_converter(filepath)
 % This function used to convert CAIMAN-cnmfe output into the form of EXTRACT output
 % that could be precomputed by ActSort.
 % 
@@ -7,10 +7,8 @@ function status = CAIMAN_to_EXTRACT_converter(filepath,savepath)
 %   [savepath]: A string or char array containing the saving path.
 %
 % OUTPUT:
-%   [status]: Showing the running state.
+%   [output]: A structure containing spatial_weights, temporal_weights, max_im, config, info.
 %
-
-status = false;
 
 %% check 1: file form
 
@@ -99,12 +97,17 @@ output.max_im = max_im;
 output.config = config;
 output.info = info;
 
-save(savepath, 'output', '-v7.3');
+if strlength(filepath) > 0 
+    % 获取 h5 文件所在目录和文件名
+    [path, name, ~] = fileparts(filepath);
 
-status = true;
-fprintf('Done! Converted data saved to %s\n', savepath);
+    % 生成新文件名
+    newFileName = name + "_precomputed.mat";
+    savepath = fullfile(path, newFileName);
 
-
+    save(savepath, 'output', '-v7.3');
+    fprintf('Converted data saved to %s\n', savepath);
+end
 
 end
 

--- a/software/PrecomputeCellCheck/helper_functions/caiman_converter.m
+++ b/software/PrecomputeCellCheck/helper_functions/caiman_converter.m
@@ -1,0 +1,110 @@
+function status = CAIMAN_to_EXTRACT_converter(filepath,savepath)
+% This function used to convert CAIMAN-cnmfe output into the form of EXTRACT output
+% that could be precomputed by ActSort.
+% 
+% INPUT:
+%   [filepath]: A string or char array containing the file path to the dataset.
+%   [savepath]: A string or char array containing the saving path.
+%
+% OUTPUT:
+%   [status]: Showing the running state.
+%
+
+status = false;
+
+%% check 1: file form
+
+try
+    info = h5info(filepath);
+catch
+    warning("Please check your input. Expected an HDF5 file.");
+    return;
+end
+
+%% check 2: runmode
+
+attr_names = {info.Attributes.Name};
+idx_runmode = find(strcmp(attr_names, 'runmode'), 1);
+
+if isempty(idx_runmode)
+    warning("No 'runmode' attribute found. This may not be a CAIMAN CNMF output.");
+    return;
+end
+
+runmode_val = info.Attributes(idx_runmode).Value;
+
+if ~strcmp(runmode_val, 'CNMF')
+    warning("runmode is not 'CNMF'.Please check your input.");
+    return;
+end
+
+%%
+dims = double(h5read(filepath, '/dims'));  % Group '/estimates' -- dim.shape = [ W , H ]
+
+temporal_weights = double(h5read(filepath, '/estimates/C'));  % Group '/estimates' -- C.shape = [ T , N ]
+
+Cn = double(h5read(filepath, '/estimates/Cn'));  % Group '/estimates' -- Cn.shape = [ W , H ]
+max_im = Cn';
+% Group '/estimates/A'
+% case: CSC sparse matrix
+% construct:  A.shape = [ W*H , N ]
+
+data    = double(h5read(filepath, '/estimates/A/data'));
+indices = double(h5read(filepath, '/estimates/A/indices'));
+indptr  = double(h5read(filepath, '/estimates/A/indptr'));
+shape   = double(h5read(filepath, '/estimates/A/shape'));
+
+n_rows = shape(1);   % H*W
+n_cols = shape(2);   % N
+
+% Python to MATLAB indexing (+1)
+indices = double(indices) + 1;
+indptr  = double(indptr) + 1;
+
+% construct sparse
+A = sparse(n_rows, n_cols);
+
+for col = 1:n_cols
+    start_idx = indptr(col);
+    end_idx   = indptr(col+1) - 1;
+
+    if start_idx <= end_idx
+        rows = indices(start_idx:end_idx);
+        vals = data(start_idx:end_idx);
+
+        A(rows, col) = vals;
+    end
+end
+
+
+Y = dims(1);
+X = dims(2);
+N = size(A, 2);
+
+
+[rows, cols, vals] = find(A);
+[y_idx, x_idx] = ind2sub([Y, X], rows);
+
+coords = [x_idx, y_idx, cols];
+values = vals;  % double type
+spatial_weights = ndSparse.build(coords, values, [X, Y, N]);
+
+config = struct();
+info = struct();
+
+output = struct();
+output.spatial_weights = spatial_weights;
+output.temporal_weights = temporal_weights;
+output.max_im = max_im;
+output.config = config;
+output.info = info;
+
+save(savepath, 'output', '-v7.3');
+
+status = true;
+fprintf('Done! Converted data saved to %s\n', savepath);
+
+
+
+end
+


### PR DESCRIPTION
**Summary**
Add algorithm selection feature to support different input formats:
- EXTRACT (native format)
- CAIMAN (via a new converter fnc)
- Suite2p (placeholder for future implementation)

**Changes**
- Add `caiman_converter` function for CAIMAN format conversion
- Add algorithm selection UI (radio buttons) in PrecomputeCellCheckGUI
- Add `algorithm` parameter to PrecomputeCellCheck (1=EXTRACT, 2=CAIMAN, 3=Suite2p)
- Fix variable naming inconsistencies in GUI
- Fix sprintf argument order in job list display

**Testing**
- Tested with EXTRACT format (.mat + .h5)
- Tested with CAIMAN format (.hdf5 + .h5)
- Verified algorithm selection works in GUI
- Verified precomputed output is valid in CellSorter

**Next Steps**
- Implement Suite2p converter (placeholder added)